### PR TITLE
Restrict mining override to only one initiated by the block

### DIFF
--- a/src/main/java/me/drex/polymerqol/mixin/mining/PolymerBlockUtilsMixin.java
+++ b/src/main/java/me/drex/polymerqol/mixin/mining/PolymerBlockUtilsMixin.java
@@ -1,27 +1,29 @@
 package me.drex.polymerqol.mixin.mining;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import eu.pb4.polymer.core.api.block.PolymerBlock;
 import eu.pb4.polymer.core.api.block.PolymerBlockUtils;
 import me.drex.polymerqol.PolymerQOL;
 import me.drex.polymerqol.networking.ClientConfiguration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PolymerBlockUtils.class)
 public abstract class PolymerBlockUtilsMixin {
-    @Inject(
+    @WrapOperation(
         method = "shouldMineServerSide",
-        at = @At("HEAD"),
-        cancellable = true
+        at = @At(value = "INVOKE", target = "Leu/pb4/polymer/core/api/block/PolymerBlock;handleMiningOnServer(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lnet/minecraft/server/level/ServerPlayer;)Z")
     )
-    private static void clientSideMining(ServerPlayer player, BlockPos pos, BlockState state, CallbackInfoReturnable<Boolean> cir) {
+    private static boolean clientSideMining(PolymerBlock instance, ItemStack tool, BlockState state, BlockPos pos, ServerPlayer player, Operation<Boolean> original) {
         ClientConfiguration clientConfiguration = PolymerQOL.getConfiguration(player);
         if (clientConfiguration.shouldMineClientSide(state)) {
-            cir.setReturnValue(false);
+            return false;
         }
+        return original.call(instance, tool, state, pos, player);
     }
 }


### PR DESCRIPTION
Simple change that should fix all cases where server side mining was initiated by an item or from an event, in cases which client can't reliably predict. Block mining will still delegate to the client when possible